### PR TITLE
Add GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,16 @@
+image: docker:stable
+
+services:
+  - docker:dind
+
+before_script:
+  - docker info
+  - apk update && apk add bash
+
+stages:
+  - test
+
+job test:
+  stage: test
+  script:
+    - ./build-docker.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ WORKDIR /build/
 
 COPY build.sh /build/
 COPY add-partition.sh /build/
+COPY mount.sh /build/
 
 ENTRYPOINT /build/build.sh

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -27,7 +27,7 @@ else
 fi
 
 echo "BUILD - Will now build Docker container"
-docker build -t edwardotme/raspbian-customiser:$BRANCH .
+docker build -t lumastar/raspbian-customiser:$BRANCH .
 
 echo "TEST - Will now test built Docker container"
 IMAGE_LINK=http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-10-11/2018-10-09-raspbian-stretch-lite.zip
@@ -43,12 +43,12 @@ docker run --privileged --rm \
   -e SCRIPT=/test/test.sh \
   -e ADD_DATA_PART=true \
   --mount type=bind,source="$(pwd)"/test,destination=/test \
-  edwardotme/raspbian-customiser:$BRANCH
+  lumastar/raspbian-customiser:$BRANCH
 
 if [ ! -z "$TAG" ]; then
 	# Only push image if TAG is set
-	echo "DEPLOY - Will now push Docker image to Docker Hub as $TAG"
-	echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-	docker tag edwardotme/raspbian-customiser:$BRANCH edwardotme/raspbian-customiser:$TAG
-	docker push edwardotme/raspbian-customiser:$TAG
+	echo "DEPLOY - Will now push Docker image to Quay.io repository as $TAG"
+	echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin quay.io
+	docker tag lumastar/raspbian-customiser:$BRANCH quay.io/lumastar/raspbian-customiser:$TAG
+	docker push quay.io/lumastar/raspbian-customiser:$TAG
 fi

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,12 +1,33 @@
 #!/usr/bin/env bash
 
 set -o errexit
-set -o nounset
+# set -o nounset
 set -o pipefail
 set -o xtrace
 
+if [ ! -z "$TRAVIS_BRANCH" ]; then
+	# For tag builds TRAVIS_BRANCH is set to the tag name
+	BRANCH=$TRAVIS_BRANCH
+	# For PR builds branch is the target branch
+	if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+		# Change the branch name for PR builds so we don't create a tag
+		BRANCH="${BRANCH}-${TRAVIS_PULL_REQUEST}"
+	fi
+	# Only Travis should push images, so we only need to use the tag with Travis
+	TAG=$TRAVIS_TAG
+	# For the master branch use the "latest" tag
+	if [ $BRANCH == "master" ]; then
+		TAG="latest"
+	fi
+elif [ ! -z "$CI_COMMIT_REF_NAME" ]; then
+	# This is also run in GitLab CI, for build and test only. 
+	BRANCH="$CI_COMMIT_REF_NAME"
+else
+	exit 1
+fi
+
 echo "BUILD - Will now build Docker container"
-docker build -t edwardotme/raspbian-customiser:$TRAVIS_BRANCH .
+docker build -t edwardotme/raspbian-customiser:$BRANCH .
 
 echo "TEST - Will now test built Docker container"
 IMAGE_LINK=http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-10-11/2018-10-09-raspbian-stretch-lite.zip
@@ -22,20 +43,12 @@ docker run --privileged --rm \
   -e SCRIPT=/test/test.sh \
   -e ADD_DATA_PART=true \
   --mount type=bind,source="$(pwd)"/test,destination=/test \
-  edwardotme/raspbian-customiser:$TRAVIS_BRANCH
-if [ $? -ne 0 ]; then
-  exit 1;
-fi
+  edwardotme/raspbian-customiser:$BRANCH
 
-if [ $TRAVIS_BRANCH == "master" ]; then
-  # For tag builds TRAVIS_BRANCH is set to the tag name
-  echo "DEPLOY - Will now push Docker image to Docker Hub as latest"
-  echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-  docker tag edwardotme/raspbian-customiser:$TRAVIS_BRANCH edwardotme/raspbian-customiser:latest
-  docker push edwardotme/raspbian-customiser:latest
-elif [ ! -z $TRAVIS_TAG ]; then
-  echo "DEPLOY - Will now push Docker image to Docker Hub as $TRAVIS_TAG"
-  echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
-  docker tag edwardotme/raspbian-customiser:$TRAVIS_BRANCH edwardotme/raspbian-customiser:$TRAVIS_TAG
-  docker push edwardotme/raspbian-customiser:$TRAVIS_TAG
+if [ ! -z "$TAG" ]; then
+	# Only push image if TAG is set
+	echo "DEPLOY - Will now push Docker image to Docker Hub as $TAG"
+	echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
+	docker tag edwardotme/raspbian-customiser:$BRANCH edwardotme/raspbian-customiser:$TAG
+	docker push edwardotme/raspbian-customiser:$TAG
 fi

--- a/build.sh
+++ b/build.sh
@@ -7,77 +7,49 @@ set -o xtrace
 
 ADD_DATA_PART=${ADD_DATA_PART:-false}
 
+# These are the env vars that should be passed in from docker
 echo "MOUNT: $MOUNT"
 echo "SOURCE_IMAGE: $SOURCE_IMAGE"
 echo "SCRIPT: $SCRIPT"
 echo "ADD_DATA_PART: $ADD_DATA_PART"
 
+# If ADD_DATA_PART is true then add a data partiton
 if [ $ADD_DATA_PART != false ]; then
 	source ./add-partition.sh $SOURCE_IMAGE
+	# The add-partition script runs mount
+else
+	# Or mount is run here directly
+	source ./mount.sh $SOURCE_IMAGE
 fi
 
-# Create loop device map from image partition table
-LOOP_DEV=$(losetup --show --find --partscan $SOURCE_IMAGE)
+# The add-partition or mount scripts must set LOOP_DEV and ROOTFS_DIR
+echo "LOOP_DEV: $LOOP_DEV"
+echo "ROOTFS_DIR: $ROOTFS_DIR"
 
-# If this fails, exit here
-if [ $? -ne 0 ]; then
-	exit 1
-fi
-
-# Wait a second or mount may fail
-sleep 1
-
-# Get list of partitions, drop the first line, as this is our
-# LOOP_DEV itself, we only what the child partitions
-PARTITIONS=$(lsblk --raw --output "MAJ:MIN" --noheadings ${LOOP_DEV} | tail -n +2)
-
-# Manually use mknod to create nodes for partitons on loop device
-# Testing indicates this is required when running in a container,
-# even if the containter is run --pivileged
-COUNTER=1
-for i in $PARTITIONS; do
-    MAJ=$(echo $i | cut -d: -f1)
-    MIN=$(echo $i | cut -d: -f2)
-    if [ ! -e "${LOOP_DEV}p${COUNTER}" ]; then mknod ${LOOP_DEV}p${COUNTER} b $MAJ $MIN; fi
-    COUNTER=$((COUNTER + 1))
-done
-
-# Make mount point and mount image
-mkdir -p /mnt/raspbian
-mount -o rw ${LOOP_DEV}p2 /mnt/raspbian
-mount -o rw ${LOOP_DEV}p1 /mnt/raspbian/boot
-
-if [ $ADD_DATA_PART != false ]; then
-	mount -o rw ${LOOP_DEV}p3 /mnt/raspbian/data
-fi
-
-# Create bind mounts for system directories
-mount --bind /dev /mnt/raspbian/dev/
-mount --bind /sys /mnt/raspbian/sys/
-mount --bind /proc /mnt/raspbian/proc/
-mount --bind /dev/pts /mnt/raspbian/dev/pts
-
-mkdir /mnt/raspbian/$MOUNT
-mount --bind $MOUNT /mnt/raspbian/$MOUNT
+# Bind mount the directory specified as MOUNT. This is for scripts to run
+# inside Raspbian and data to copy in
+mkdir ${ROOTFS_DIR}/${MOUNT}
+mount --bind $MOUNT ${ROOTFS_DIR}/${MOUNT}
 
 # Apply ld.so.preload fix
 sed -i 's/^/#CHROOT /g' /mnt/raspbian/etc/ld.so.preload
 
 # Copy qemu binary
-cp /usr/bin/qemu-arm-static /mnt/raspbian/usr/bin/
+cp /usr/bin/qemu-arm-static ${ROOTFS_DIR}/usr/bin/
 
 # Enable qemu-arm
 update-binfmts --enable qemu-arm
 
-# Chroot to raspbian
-chroot /mnt/raspbian $SCRIPT
+# Chroot to the mounted Raspbian environment and run the SCRIPT
+chroot ${ROOTFS_DIR} $SCRIPT
 
 # Revert ld.so.preload fix
-sed -i 's/^#CHROOT //g' /mnt/raspbian/etc/ld.so.preload
+sed -i 's/^#CHROOT //g' ${ROOTFS_DIR}/etc/ld.so.preload
 
 # Unmount everything
 if [ $ADD_DATA_PART != false ]; then
-	umount /mnt/raspbian/data
+	umount ${ROOTFS_DIR}/data
 fi
-umount /mnt/raspbian/{dev/pts,dev,sys,proc,boot,${MOUNT},}
+umount ${ROOTFS_DIR}/{dev/pts,dev,sys,proc,boot,${MOUNT},}
 losetup -d $LOOP_DEV
+echo "SUCCESSFULLY UNMOUNTED IMG"

--- a/mount.sh
+++ b/mount.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+# We can do this the easy way, or the hard way...
+if [ -e /dev/loop0 ]; then
+	# Mount the image as a loop device
+	LOOP_DEV=$(losetup --show --find --partscan $IMG_FILE)
+else
+	# Oh I see you've chosen the hard way...
+	# Mount host /dev to /tmp/dev
+	mkdir -p /tmp/dev
+	mount -t devtmpfs none /tmp/dev
+	# Use mknod to manually create loop devices
+	mknod -m 0660 "/tmp/dev/loop0" b 7 0
+	# Mount the image as a loop device
+	LOOP_DEV=$(losetup --show --partscan "/tmp/dev/loop0" $IMG_FILE)
+fi
+# Make the LOOP_DEV env var available to other scripts
+export LOOP_DEV
+
+# Wait a second or mount may fail
+sleep 1
+
+# Get list of partitions, drop the first line, as this is our
+# LOOP_DEV itself, we only what the child partitions
+PARTITIONS=$(lsblk --raw --output "MAJ:MIN" --noheadings ${LOOP_DEV} | tail -n +2)
+
+# Manually use mknod to create nodes for partitons on loop device
+# Testing indicates this is required when running in a container,
+# even if the containter is run --pivileged
+COUNTER=1
+for i in $PARTITIONS; do
+    MAJ=$(echo $i | cut -d: -f1)
+    MIN=$(echo $i | cut -d: -f2)
+    if [ ! -e "${LOOP_DEV}p${COUNTER}" ]; then mknod ${LOOP_DEV}p${COUNTER} b $MAJ $MIN; fi
+    COUNTER=$((COUNTER + 1))
+done
+
+# Make mount point, mount image and make the ROOTFS_DIR env var available to
+# other scripts
+export ROOTFS_DIR=/mnt/raspbian
+mkdir -p $ROOTFS_DIR
+mount -o rw ${LOOP_DEV}p2 $ROOTFS_DIR
+mount -o rw ${LOOP_DEV}p1 ${ROOTFS_DIR}/boot
+
+# Create bind mounts for system directories
+mount --bind /dev /mnt/raspbian/dev/
+mount --bind /sys /mnt/raspbian/sys/
+mount --bind /proc /mnt/raspbian/proc/
+mount --bind /dev/pts /mnt/raspbian/dev/pts
+
+# List the contents of mount point to verify mount was successful
+echo "CONTENTS OF /:"
+ls ${ROOTFS_DIR}
+echo "CONTENTS OF /boot:"
+ls ${ROOTFS_DIR}/boot


### PR DESCRIPTION
GitLab CI is also used to build and test the image. This is because the two CI/CD systems seem to handle loop devices differently. As the raspbian-customiser is used by projects in both environments its important that both are functional.