### PR TITLE
Expand file system

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+test/
+.gitignore
+.gitlab-ci.yml
+.travis.yml
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+test/*.img
+test/*.zip

--- a/add-partition.sh
+++ b/add-partition.sh
@@ -66,7 +66,7 @@ parted -a none -s "${IMG_FILE}" mkpart primary "${PART_TYPE}" "${PART_START}B" 1
 # Use parted to print the partition table
 parted -s "${IMG_FILE}" unit b print free
 
-# Check the partiton is optimally aligned
+# Check the partition is optimally aligned
 parted -s "${IMG_FILE}" align-check opt 3
 
 # Mount the image

--- a/add-partition.sh
+++ b/add-partition.sh
@@ -9,6 +9,8 @@ set -o xtrace
 
 IMG_FILE=$1
 
+echo "IMG_FILE: $IMG_FILE"
+
 # These could be set by args
 # Size should be in MiB
 PART_SIZE=64

--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,8 @@ if [ ! -z "$TRAVIS_BRANCH" ]; then
 elif [ ! -z "$CI_COMMIT_REF_NAME" ]; then
 	# This is also run in GitLab CI, for build and test only. 
 	BRANCH="$CI_COMMIT_REF_NAME"
+elif [ ! -z "$LOCAL" ]; then
+    BRANCH="local-test"
 else
 	exit 1
 fi
@@ -31,11 +33,12 @@ docker build -t lumastar/raspbian-customiser:$BRANCH .
 
 echo "TEST - Will now test built Docker container"
 IMAGE_LINK=http://downloads.raspberrypi.org/raspbian_lite/images/raspbian_lite-2018-10-11/2018-10-09-raspbian-stretch-lite.zip
-cd test/
-wget -nv $IMAGE_LINK
 IMAGE_ZIP=$(basename $IMAGE_LINK)
+cd test/
+if [ ! -f "$IMAGE_ZIP" ]; then
+    wget -nv $IMAGE_LINK
+fi
 unzip -o $IMAGE_ZIP
-rm $IMAGE_ZIP
 cd ..
 docker run --privileged --rm \
   -e MOUNT=/test \

--- a/customise.sh
+++ b/customise.sh
@@ -29,6 +29,13 @@ else
 	source ./mount.sh $SOURCE_IMAGE
 fi
 
+# If we expanded the root partition now that the image is mounted we must also
+# expand the file system
+if [ $EXPAND -gt "0" ]; then
+    e2fsck -f ${LOOP_DEV}p2
+    resize2fs ${LOOP_DEV}p2
+fi
+
 # The add-partition or mount scripts must set LOOP_DEV and ROOTFS_DIR
 echo "LOOP_DEV: $LOOP_DEV"
 echo "ROOTFS_DIR: $ROOTFS_DIR"

--- a/customise.sh
+++ b/customise.sh
@@ -29,13 +29,6 @@ else
 	source ./mount.sh $SOURCE_IMAGE
 fi
 
-# If we expanded the root partition now that the image is mounted we must also
-# expand the file system
-if [ $EXPAND -gt "0" ]; then
-    e2fsck -f ${LOOP_DEV}p2
-    resize2fs ${LOOP_DEV}p2
-fi
-
 # The add-partition or mount scripts must set LOOP_DEV and ROOTFS_DIR
 echo "LOOP_DEV: $LOOP_DEV"
 echo "ROOTFS_DIR: $ROOTFS_DIR"

--- a/expand.sh
+++ b/expand.sh
@@ -8,26 +8,45 @@ set -o xtrace
 # Set EXPAND to first argument, or 0 if not provided
 EXPAND="${1:-0}"
 
-# Determine the current size of the partition
-SIZE_BEFORE=$(parted -s "${SOURCE_IMAGE}" unit Mib print | grep -e '^ 2' \
-| xargs echo -n | cut -d" " -f 4 | tr -d MiB)
+echo "SOURCE_IMAGE: $SOURCE_IMAGE"
+echo "EXPAND: $EXPAND"
 
-# Add EXPAND * 1M to the end of the image
-dd bs=1M if=/dev/zero count=$EXPAND >> $SOURCE_IMAGE
+# Convert from MiB to B
+PART_EXPAND=$(($EXPAND * 1024 * 1024))
+# Ensure the expansion aligns with 4096B (and therefore also 512B) sectors
+PART_EXPAND=$(($PART_EXPAND / 4096))
+PART_EXPAND=$((($PART_EXPAND + 1) * 4096))
+# Convert to KiB for quicker dd
+PART_EXPAND=$(($PART_EXPAND / 1024))
+
+# Determine the current size of the partition
+SIZE_BEFORE=$(parted -s "${SOURCE_IMAGE}" unit KiB print | grep -e '^ 2' \
+| xargs echo -n | cut -d" " -f 4 | tr -d kiB)
+
+# Find the end of the root partition
+# This assumes there are two partitions
+ROOT_END=$(parted -s "${SOURCE_IMAGE}" unit KiB print | grep -e '^ 2' \
+| xargs echo -n | cut -d" " -f 3 | tr -d kiB)
+
+ROOT_END_NEW=$(($ROOT_END + $PART_EXPAND - 1))
+
+parted -s "${SOURCE_IMAGE}" unit KiB print free
+
+dd bs=1K if=/dev/zero count=$PART_EXPAND >> $SOURCE_IMAGE
+
+parted -s "${SOURCE_IMAGE}" unit KiB print free
 
 # Resize the second partition to fill the free space
-parted -s "${SOURCE_IMAGE}" resizepart 2 100%
+parted -s "${SOURCE_IMAGE}" resizepart 2 "${ROOT_END_NEW}KiB"
+
+parted -s "${SOURCE_IMAGE}" unit KiB print free
 
 # Determine the new size of the partition
-SIZE_AFTER=$(parted -s "${SOURCE_IMAGE}" unit Mib print | grep -e '^ 2' \
-| xargs echo -n | cut -d" " -f 4 | tr -d MiB)
+SIZE_AFTER=$(parted -s "${SOURCE_IMAGE}" unit KiB print | grep -e '^ 2' \
+| xargs echo -n | cut -d" " -f 4 | tr -d kiB)
 
 SIZE_DIFFERENCE=$(($SIZE_AFTER - $SIZE_BEFORE))
-# Expanding to 100% may actually expand the partition slightly more than the
-# specified amount as the image file may have other empty space at the end. As
-# long as the size difference isn't less than the specified amount then this
-# check can pass.
-if [ "$SIZE_DIFFERENCE" -lt "$EXPAND" ]; then
+if [ "$SIZE_DIFFERENCE" != "$PART_EXPAND" ]; then
     echo "Expand error, SIZE_BEFORE: $SIZE_BEFORE, SIZE_AFTER: $SIZE_AFTER, SIZE_DIFFERENCE: $SIZE_DIFFERENCE"
     exit 1
 fi

--- a/expand.sh
+++ b/expand.sh
@@ -23,7 +23,11 @@ SIZE_AFTER=$(parted -s "${SOURCE_IMAGE}" unit Mib print | grep -e '^ 2' \
 | xargs echo -n | cut -d" " -f 4 | tr -d MiB)
 
 SIZE_DIFFERENCE=$(($SIZE_AFTER - $SIZE_BEFORE))
-if [ "$SIZE_DIFFERENCE" != "$EXPAND" ]; then
+# Expanding to 100% may actually expand the partition slightly more than the
+# specified amount as the image file may have other empty space at the end. As
+# long as the size difference isn't less than the specified amount then this
+# check can pass.
+if [ "$SIZE_DIFFERENCE" -lt "$EXPAND" ]; then
     echo "Expand error, SIZE_BEFORE: $SIZE_BEFORE, SIZE_AFTER: $SIZE_AFTER, SIZE_DIFFERENCE: $SIZE_DIFFERENCE"
     exit 1
 fi

--- a/mount.sh
+++ b/mount.sh
@@ -45,7 +45,7 @@ done
 # If we expanded the root partition we must also expand the file system. This
 # must be done after loop device creation but before mounting.
 if [ $EXPAND -gt "0" ]; then
-    e2fsck -f ${LOOP_DEV}p2
+    e2fsck -fp -B 512 ${LOOP_DEV}p2
     resize2fs ${LOOP_DEV}p2
 fi
 

--- a/mount.sh
+++ b/mount.sh
@@ -5,6 +5,8 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
+IMG_FILE=$1
+
 # We can do this the easy way, or the hard way...
 if [ -e /dev/loop0 ]; then
 	# Mount the image as a loop device

--- a/mount.sh
+++ b/mount.sh
@@ -42,6 +42,13 @@ for i in $PARTITIONS; do
     COUNTER=$((COUNTER + 1))
 done
 
+# If we expanded the root partition we must also expand the file system. This
+# must be done after loop device creation but before mounting.
+if [ $EXPAND -gt "0" ]; then
+    e2fsck -f ${LOOP_DEV}p2
+    resize2fs ${LOOP_DEV}p2
+fi
+
 # Make mount point, mount image and make the ROOTFS_DIR env var available to
 # other scripts
 export ROOTFS_DIR=/mnt/raspbian


### PR DESCRIPTION
If `expand.sh` is run we should also expand the file system after the image is mounted.

This also fixes an issue with `mount.sh` not setting `IMG_FILE` from arguments as it should.